### PR TITLE
Fix _check_medoids method

### DIFF
--- a/kmedoids/__init__.py
+++ b/kmedoids/__init__.py
@@ -78,6 +78,7 @@ class KMedoidsResult:
 
 def _check_medoids(diss, medoids, init, random_state):
 	"""Check the medoids and random_state parameters."""
+	import warnings
 	import numpy as np, numbers
 	if isinstance(medoids, np.ndarray):
 		if random_state is not None:


### PR DESCRIPTION
Addresses [Issue 8](https://github.com/kno10/python-kmedoids/issues/8).

`_check_medoids` calls `warnings` but doesn't import the module. This
fix adds the import statement within the function scope.